### PR TITLE
chore(exabot-k8s): Bump version to 0.0.7

### DIFF
--- a/charts/exabot-k8s/Chart.yaml
+++ b/charts/exabot-k8s/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.3"
+appVersion: "0.0.4"

--- a/charts/exabot-k8s/README.md
+++ b/charts/exabot-k8s/README.md
@@ -1,6 +1,6 @@
 # exabot-k8s
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.4](https://img.shields.io/badge/AppVersion-0.0.4-informational?style=flat-square)
 
 A Helm chart for exaforce exabot-k8s
 
@@ -52,7 +52,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | image.name | string | `"exabot-k8s"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"public.ecr.aws/k5x9t2h7"` |  |
-| image.tag | string | `"0.0.3"` |  |
+| image.tag | string | `"0.0.4"` |  |
 | rbac.enabled | bool | `true` |  |
 
 ----------------------------------------------

--- a/charts/exabot-k8s/values.yaml
+++ b/charts/exabot-k8s/values.yaml
@@ -7,7 +7,7 @@ image:
   name: exabot-k8s
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.3"
+  tag: "0.0.4"
 
 exabotK8s:
   env:


### PR DESCRIPTION
Update chart version to 0.0.7 and app version to 0.0.4 to align with the latest exabot-k8s image release